### PR TITLE
Adds optional runtime config argument to SimpleNonce class constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,26 @@ $ composer require softsmart/simple-nonce
 
 ``` php
 // Generate Nonce
-$userID = 1; // This is the user account we're about to delete
+$UserID = 1; // This is the user account we're about to delete
 
 $action = "deleteUser";
 $meta = [$UserID];
 
-$nonceValues = SimpleNonce::GenerateNonce($action, $meta);
+// Optionally set configuration at runtime, else use config.inc.php
+$nonceConfig = ["salt"=>"your-salt", "ttl"=>3600];
+$nonceEngine = new \SoftSmart\Utilities\SimpleNonce($nonceConfig);
+
+$nonceValues = $nonceEngine->generateNonce($action, $meta);
 header("Location: ./deleteUser.php?userID=".$userID."&nonce=".$nonceValues["nonce"]."&timeStamp=".$nonceValues["timeStamp"]);
 
 
 // Verify Nonce
-$userID = 1; // This is the user account we're about to delete
+$UserID = 1; // This is the user account we're about to delete
 
 $action = "deleteUser";
 $meta = [$UserID];
 
-$result = SimpleNonce::VerifyNonce($nonceValues["nonce"], $action, $nonceValues["timeStamp"], $meta);
+$result = SimpleNonce::verifyNonce($nonceValues["nonce"], $action, $nonceValues["timeStamp"], $meta);
 
 if( ! $Result )
 {

--- a/src/SimpleNonce.php
+++ b/src/SimpleNonce.php
@@ -37,21 +37,27 @@ class SimpleNonce
     * Constructor. Set's the tmp directory and calls the protected
     * function manageNonceTempFiles which deletes stale tmp files
     */
-    function __construct() 
+    function __construct($runtime_config = []) 
     {
         include dirname(__FILE__)."/config.inc.php";
     
-        if (isset($config["salt"])) {
+    	if (isset($runtime_config["salt"])) {
+    		$this->nonceSalt = $runtime_config["salt"];
+        } else if (isset($config["salt"])) {
             $this->nonceSalt = $config["salt"];
         }
     
-        if (isset($config["ttl"])) {
+    	if (isset($runtime_config["ttl"])) {
+    		$this->nonceExpiryTime = $runtime_config["ttl"];
+        } else if (isset($config["ttl"])) {
             $this->nonceExpiryTime = $config["ttl"];
         }
     
         // where will the nonce files be saved
         $this->path = dirname(__FILE__)."/nonce"; 
-        if (isset($config["tmpPath"])) {
+        if (isset($runtime_config["tmpPath"])) {
+        	$this->path = $runtime_config["tmpPath"];
+        } else if (isset($config["tmpPath"])) {
             $this->path = $config["tmpPath"];
         }
     

--- a/tests/SimpleNonceTest.php
+++ b/tests/SimpleNonceTest.php
@@ -68,4 +68,17 @@ class SimpleNonceTest extends \PHPUnit\Framework\TestCase
     }
 
 
+    public function testNonceAcceptsRuntimeConfig()
+    {
+    	$oSimpleNonce = new \SoftSmart\Utilities\SimpleNonce(["salt"=>"your-salt", "ttl"=>3600]);
+
+    $action = "test";
+	$meta = ["testNonceAcceptsRuntimeConfig"];
+	
+	$result = $oSimpleNonce->generateNonce($action, $meta);
+	
+	$this->assertNotEmpty($result);
+    }
+
+
 }


### PR DESCRIPTION
Adds an optional argument to the SimpleNonce class constructor which accepts an array of the three configuration options in config.inc.php. Options set in this way override options set in config.inc.php.

The reason is so developers can seamlessly receive branch updates with composer without worry about overwriting their config file. Also this allows for more flexibility since multiple salts, ttls, and paths can be set within a single project.

Example using runtime config argument:
`$nonceEngine = new \SoftSmart\Utilities\SimpleNonce(["salt"=>"your-salt", "ttl"=>3600]);`